### PR TITLE
Escape quotes and other entities as part of transform to junit xml.

### DIFF
--- a/convert-junit.js
+++ b/convert-junit.js
@@ -1,4 +1,5 @@
 const {mapSeverity} = require("./convert");
+const xmlEscape = require('xml-escape');
 
 const convertJunit = (input) => {
   const testSuites = input.results?.flatMap(convertResults) || [];
@@ -14,10 +15,10 @@ const convertJunit = (input) => {
 const convertResults = (input) => {
   return input.packages?.flatMap(pack => pack.vulnerabilities.map(vulnerability => {
     const severity = mapSeverity(vulnerability?.database_specific?.severity || "Unknown");
-
+    const summary = xmlEscape(vulnerability.summary);
     return `
-<testcase name="[${severity}][${vulnerability.id}][${pack["package"].name}] ${vulnerability.summary}" file="${input.source.path}" classname="${pack["package"].name}">
-  <failure type="failure" message="${vulnerability.summary}"><![CDATA[${severity}][${vulnerability.id}][${pack["package"].name}] ${vulnerability.summary}\n${vulnerability.details}]]></failure>
+<testcase name="[${severity}][${vulnerability.id}][${pack["package"].name}] ${summary}" file="${input.source.path}" classname="${pack["package"].name}">
+  <failure type="failure" message="${summary}"><![CDATA[${severity}][${vulnerability.id}][${pack["package"].name}] ${vulnerability.summary}\n${(vulnerability.details)}]]></failure>
 </testcase>
 `;
   }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "osv2gitlab",
       "version": "1.1.0",
+      "dependencies": {
+        "xml-escape": "^1.1.0"
+      },
       "bin": {
         "osv2gitlab": "index.js"
       },
@@ -307,6 +310,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/xml-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+      "integrity": "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "ajv-cli": "^5.0.0",
     "fast-xml-parser": "^4.5.0"
   },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610",
+  "dependencies": {
+    "xml-escape": "^1.1.0"
+  }
 }

--- a/report.json
+++ b/report.json
@@ -2287,6 +2287,501 @@
                 "nvd_published_at": null,
                 "severity": "HIGH"
               }
+            },
+            {
+              "modified": "2024-10-22T05:28:59Z",
+              "published": "2024-05-14T15:32:54Z",
+              "schema_version": "1.6.0",
+              "id": "GHSA-v435-xc8x-wvr9",
+              "aliases": [
+                "CGA-2f4h-fc34-cw83",
+                "CGA-5mrq-75x2-g8hj",
+                "CGA-9qv8-44xh-vf2p",
+                "CVE-2024-30171"
+              ],
+              "related": [
+                "CGA-35r6-m6p6-xc93",
+                "CGA-38cm-jrfp-jgjm",
+                "CGA-3cjr-985f-7r7h",
+                "CGA-8595-m6wp-3rgq",
+                "CGA-9727-f845-q3xw",
+                "CGA-9c2c-7969-vffw",
+                "CGA-9vcm-5pxq-pvv5",
+                "CGA-fcmx-xq2g-xppj",
+                "CGA-g4x8-993m-grwh",
+                "CGA-gfj5-2q78-6f2f",
+                "CGA-h543-7w38-mv7r",
+                "CGA-j49x-3x3f-7v84",
+                "CGA-vwqh-4f8x-m5r2"
+              ],
+              "summary": "Bouncy Castle affected by timing side-channel for RSA key exchange (\"The Marvin Attack\")",
+              "details": "An issue was discovered in Bouncy Castle Java TLS API and JSSE Provider before 1.78. Timing-based leakage may occur in RSA based handshakes because of exception processing.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Maven",
+                    "name": "org.bouncycastle:bctls-fips",
+                    "purl": "pkg:maven/org.bouncycastle/bctls-fips"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.0.19"
+                        }
+                      ]
+                    }
+                  ],
+                  "versions": [
+                    "1.0.0",
+                    "1.0.1",
+                    "1.0.10",
+                    "1.0.10.1",
+                    "1.0.10.2",
+                    "1.0.10.3",
+                    "1.0.11",
+                    "1.0.11.1",
+                    "1.0.11.2",
+                    "1.0.11.3",
+                    "1.0.11.4",
+                    "1.0.12",
+                    "1.0.12.1",
+                    "1.0.12.2",
+                    "1.0.12.3",
+                    "1.0.13",
+                    "1.0.14",
+                    "1.0.14.1",
+                    "1.0.16",
+                    "1.0.17",
+                    "1.0.18",
+                    "1.0.2",
+                    "1.0.3",
+                    "1.0.4",
+                    "1.0.5",
+                    "1.0.6",
+                    "1.0.7",
+                    "1.0.8",
+                    "1.0.9"
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "Maven",
+                    "name": "org.bouncycastle:bcprov-jdk18on",
+                    "purl": "pkg:maven/org.bouncycastle/bcprov-jdk18on"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.78"
+                        }
+                      ]
+                    }
+                  ],
+                  "versions": [
+                    "1.71",
+                    "1.71.1",
+                    "1.72",
+                    "1.73",
+                    "1.74",
+                    "1.75",
+                    "1.76",
+                    "1.77"
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "Maven",
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "purl": "pkg:maven/org.bouncycastle/bcprov-jdk15on"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.78"
+                        }
+                      ]
+                    }
+                  ],
+                  "versions": [
+                    "1.46",
+                    "1.47",
+                    "1.48",
+                    "1.49",
+                    "1.50",
+                    "1.51",
+                    "1.52",
+                    "1.53",
+                    "1.54",
+                    "1.55",
+                    "1.56",
+                    "1.57",
+                    "1.58",
+                    "1.59",
+                    "1.60",
+                    "1.61",
+                    "1.62",
+                    "1.63",
+                    "1.64",
+                    "1.65",
+                    "1.65.01",
+                    "1.66",
+                    "1.67",
+                    "1.68",
+                    "1.69",
+                    "1.70"
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "Maven",
+                    "name": "org.bouncycastle:bcprov-jdk15to18",
+                    "purl": "pkg:maven/org.bouncycastle/bcprov-jdk15to18"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.78"
+                        }
+                      ]
+                    }
+                  ],
+                  "versions": [
+                    "1.63",
+                    "1.64",
+                    "1.65",
+                    "1.66",
+                    "1.67",
+                    "1.68",
+                    "1.69",
+                    "1.70",
+                    "1.71",
+                    "1.72",
+                    "1.73",
+                    "1.74",
+                    "1.75",
+                    "1.76",
+                    "1.77"
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "Maven",
+                    "name": "org.bouncycastle:bcprov-jdk14",
+                    "purl": "pkg:maven/org.bouncycastle/bcprov-jdk14"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.78"
+                        }
+                      ]
+                    }
+                  ],
+                  "versions": [
+                    "1.38",
+                    "1.43",
+                    "1.44",
+                    "1.45",
+                    "1.46",
+                    "1.47",
+                    "1.48",
+                    "1.49",
+                    "1.50",
+                    "1.51",
+                    "1.53",
+                    "1.54",
+                    "1.55",
+                    "1.56",
+                    "1.57",
+                    "1.58",
+                    "1.59",
+                    "1.60",
+                    "1.61",
+                    "1.62",
+                    "1.63",
+                    "1.64",
+                    "1.65",
+                    "1.67",
+                    "1.68",
+                    "1.69",
+                    "1.70",
+                    "1.71",
+                    "1.72",
+                    "1.73",
+                    "1.74",
+                    "1.75",
+                    "1.76",
+                    "1.77"
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "Maven",
+                    "name": "org.bouncycastle:bctls-jdk18on",
+                    "purl": "pkg:maven/org.bouncycastle/bctls-jdk18on"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.78"
+                        }
+                      ]
+                    }
+                  ],
+                  "versions": [
+                    "1.71",
+                    "1.71.1",
+                    "1.72",
+                    "1.73",
+                    "1.74",
+                    "1.75",
+                    "1.76",
+                    "1.77"
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "Maven",
+                    "name": "org.bouncycastle:bctls-jdk14",
+                    "purl": "pkg:maven/org.bouncycastle/bctls-jdk14"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.78"
+                        }
+                      ]
+                    }
+                  ],
+                  "versions": [
+                    "1.61",
+                    "1.62",
+                    "1.63",
+                    "1.64",
+                    "1.65",
+                    "1.67",
+                    "1.68",
+                    "1.69",
+                    "1.70",
+                    "1.71",
+                    "1.72",
+                    "1.73",
+                    "1.74",
+                    "1.75",
+                    "1.76",
+                    "1.77"
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "Maven",
+                    "name": "org.bouncycastle:bctls-jdk15to18",
+                    "purl": "pkg:maven/org.bouncycastle/bctls-jdk15to18"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.78"
+                        }
+                      ]
+                    }
+                  ],
+                  "versions": [
+                    "1.63",
+                    "1.64",
+                    "1.65",
+                    "1.66",
+                    "1.67",
+                    "1.68",
+                    "1.69",
+                    "1.70",
+                    "1.71",
+                    "1.72",
+                    "1.73",
+                    "1.74",
+                    "1.75",
+                    "1.76",
+                    "1.77"
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "NuGet",
+                    "name": "BouncyCastle",
+                    "purl": "pkg:nuget/BouncyCastle"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  "versions": [
+                    "1.7.0",
+                    "1.8.1",
+                    "1.8.2",
+                    "1.8.3",
+                    "1.8.3.1",
+                    "1.8.4",
+                    "1.8.5",
+                    "1.8.6",
+                    "1.8.6.1",
+                    "1.8.9"
+                  ],
+                  "database_specific": {
+                    "last_known_affected_version_range": "\u003c 2.3.1",
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "NuGet",
+                    "name": "BouncyCastle.Cryptography",
+                    "purl": "pkg:nuget/BouncyCastle.Cryptography"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "2.3.1"
+                        }
+                      ]
+                    }
+                  ],
+                  "versions": [
+                    "2.0.0",
+                    "2.1.0",
+                    "2.1.1",
+                    "2.2.0",
+                    "2.2.1",
+                    "2.3.0"
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json"
+                  }
+                }
+              ],
+              "severity": [
+                {
+                  "type": "CVSS_V3",
+                  "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                }
+              ],
+              "references": [
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-30171"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/bcgit/bc-csharp/commit/c984b8bfd8544dfc55dba91a02cbbbb9c580c217"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/bcgit/bc-java/commit/d7d5e735abd64bf0f413f54fd9e495fc02400fb0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/bcgit/bc-java/commit/e0569dcb1dea9d421d84fc4c5c5688fe101afa2d"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/bcgit/bc-csharp/wiki/CVE%E2%80%902024%E2%80%9030171"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/bcgit/bc-java/wiki/CVE%E2%80%902024%E2%80%9030171"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://security.netapp.com/advisory/ntap-20240614-0008"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://www.bouncycastle.org/latest_releases.html"
+                }
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-203"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2024-05-14T20:22:03Z",
+                "nvd_published_at": "2024-05-14T15:21:52Z",
+                "severity": "MODERATE"
+              }
             }
           ],
           "groups": [


### PR DESCRIPTION
The problem:

If a vulnerability `summary` or `detail` attribute value contains XML meta-characters e.g. a double quote, this package produces invalid Junit XML which can't be processed by gitlab.

The fix:
- escape attribute values while transforming vulnerabilites to junit xml
- only escape in `testcase.name` and `failure.message` attributes, the inner CDATA in failure can cope with embedded metacharacters and testing with `fxparser` will correctly revert them to escaped double quotes.

Other considerations:
- `xml-escape` is a tiny package, but it would not be hard to create an equivalent function if you want to avoid introducing dependencies
